### PR TITLE
add demand from ENTSO-E ERAA

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -60,7 +60,8 @@ if config["solving_option"] == "together":
             network2030 = config['n_2030'],
             network2025 = config['n_2025'],
             costs2030=CDIR + "/costs_2030.csv",
-            costs2025=CDIR + "/costs_2025.csv"
+            costs2025=CDIR + "/costs_2025.csv",
+            demand = "data/Demand/Demand_Time_Series/Demand_TimeSeries_{year}_NationalTrends_without_bat.xlsx"
         output:
             network=RDIR + "/networks/{year}/{zone}/{palette}/{policy}_{res_share}_{offtake_volume}volume_{storage}.nc"
         log:

--- a/config.yaml
+++ b/config.yaml
@@ -30,7 +30,7 @@ scenario:
   offtake_volume: [3200] # [3200, 6050]  # [MWh_H2 per h] fixed offtake volume per hour, updated German hydrogen strategy, local production between 28-53 TWh_H2 per year in 2030, 10 GB planned in DE by 2030 if run 100% 10GB*0.67=6700MWh/h
   storage: ["flexibledemand", "nostore"] # ["flexibledemand", "underground", "mtank", "htank", "nostore"]  # storage type at hydrogen production
   h2_demand_added: False
-  temporal_resolution: "1H"
+  temporal_resolution: "24H"
   DE_target: True
 
 
@@ -43,7 +43,7 @@ ci:
 # regional coverage of the model: "regions" or "EU"
 # "regions" -> strips the model to country where CI load is located + all neighboring countries
 # "EU" -> keeps the whole European power system (full ENTSO-E area)
-area: "test" #"regions"
+area: "regions" #"regions"
 
 ###################
 # Fixed settings


### PR DESCRIPTION
This PR adds demand data from [ENTSO-E ERAA](https://www.entsoe.eu/outlooks/eraa/2022/eraa-downloads/) for the corresponding year and weather year 2013.
Since this data set does not include GB the demand time-series of GB are scaled up depending on the average increase over all considered countries.

To run the workflow you first have to download the demand time series from ENTSO-E ERAA and store them in the directory under `data/Demand/Demand_Time_Series/Demand_TimeSeries_2030_NationalTrends_without_bat.xlsx`